### PR TITLE
Update README with the latest version of juniversalchardet

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Put this dependency in your pom.xml
 <dependency>
 	<groupId>com.github.albfernandez</groupId>
 	<artifactId>juniversalchardet</artifactId>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 </dependency>
 
 ```


### PR DESCRIPTION
Update README with the latest version of juniversalchardet.


Perhaps you could also please check that OpenPDF is using juniversalchardet correctly here?
https://github.com/LibrePDF/OpenPDF/blob/master/openpdf/src/main/java/com/lowagie/text/xml/simpleparser/SimpleXMLParser.java#L564