### PR TITLE
Adds "Getting with gradle" part to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Put this dependency in your pom.xml
 
 ```
 
+## Getting with gradle
+
+Put this line in your build.gradle
+
+```groovy
+implementation 'com.github.albfernandez:juniversalchardet:2.3.0'
+```
+
 ## Building from sources
 
 ```bash


### PR DESCRIPTION
It is a bit tricky and confusing to transform maven to gradle dependency, so having a dedicated gradle paragraph in the `README.md` is nice.