### PR TITLE
Update build to pass when using JDK14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,19 +77,16 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.0.0</version>
 				<executions>
 					<execution>
-						<id>findbugs-check</id>
+						<id>spotbugs-check</id>
 						<phase>verify</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>
-						<configuration>
-							<failOnError>true</failOnError>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -125,13 +122,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<source>${compiler.level}</source>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
When attempting to build using JDK14, both javadoc and findbugs failed. Updated version of javadoc and added source configuration. Upgraded findbugs to spotbugs which is the replacement to findbugs.