### PR TITLE
Update to make JPMS compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
 	<properties>
 		<compiler.level>1.7</compiler.level>
+		<compiler.module.level>9</compiler.module.level>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -69,7 +70,26 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.1</version>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<configuration>
+							<release>${compiler.module.level}</release>
+						</configuration>
+					</execution>
+					<execution>
+						<id>base-compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<exclude>module-info.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
 				<configuration>
 					<source>${compiler.level}</source>
 					<target>${compiler.level}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -77,19 +77,16 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.0.0</version>
 				<executions>
 					<execution>
-						<id>findbugs-check</id>
+						<id>spotbugs-check</id>
 						<phase>verify</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>
-						<configuration>
-							<failOnError>true</failOnError>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -125,13 +122,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<source>${compiler.level}</source>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module com.github.albfernandez.juniversalchardet {
+    exports org.mozilla.universalchardet;
+    exports org.mozilla.universalchardet.prober;
+    exports org.mozilla.universalchardet.prober.contextanalysis;
+    exports org.mozilla.universalchardet.prober.distributionanalysis;
+    exports org.mozilla.universalchardet.prober.sequence;
+    exports org.mozilla.universalchardet.prober.statemachine;
+}


### PR DESCRIPTION
I exported all packages in the module-info.java. If the prober.* packages should be internal, need to remove them from the module-info.