### PR TITLE
Fix typo in ASCII charset constant

### DIFF
--- a/src/main/java/org/mozilla/universalchardet/Constants.java
+++ b/src/main/java/org/mozilla/universalchardet/Constants.java
@@ -56,7 +56,7 @@ public final class Constants {
     public static final String CHARSET_UTF_32BE     = "UTF-32BE".intern();
     public static final String CHARSET_UTF_32LE     = "UTF-32LE".intern();
     public static final String CHARSET_TIS620       = "TIS620".intern();
-    public static final String CHARSET_US_ASCCI     = "US-ASCII".intern();
+    public static final String CHARSET_US_ASCII     = "US-ASCII".intern();
     
     
     // WARNING: Listed below are charsets which Java does not support.

--- a/src/main/java/org/mozilla/universalchardet/UniversalDetector.java
+++ b/src/main/java/org/mozilla/universalchardet/UniversalDetector.java
@@ -43,7 +43,7 @@
 
 package org.mozilla.universalchardet;
 
-import static org.mozilla.universalchardet.Constants.CHARSET_US_ASCCI;
+import static org.mozilla.universalchardet.Constants.CHARSET_US_ASCII;
 import static org.mozilla.universalchardet.Constants.CHARSET_UTF_16BE;
 import static org.mozilla.universalchardet.Constants.CHARSET_UTF_16LE;
 import static org.mozilla.universalchardet.Constants.CHARSET_UTF_32BE;
@@ -313,7 +313,7 @@ public class UniversalDetector {
         } else if (this.inputState == InputState.ESC_ASCII) {
             // do nothing
         } else if (this.inputState == InputState.PURE_ASCII && this.onlyPrintableASCII) {
-        	this.detectedCharset = CHARSET_US_ASCCI;
+        	this.detectedCharset = CHARSET_US_ASCII;
         }
         else {
             // do nothing


### PR DESCRIPTION
As the typo was only in the constant name, this fix shouldn't affect the external interface of the UniversalDetector class.